### PR TITLE
fix: Body's reader is now optional; may be checked for emptiness

### DIFF
--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -42,10 +42,16 @@ impl HttpClient for IsahcClient {
         let client = self.client.clone();
         Box::pin(async move {
             let (parts, body) = req.into_parts();
-            let body = match body.len {
-                Some(len) => isahc::Body::reader_sized(body, len),
-                None => isahc::Body::reader(body),
+
+            let body = if body.is_empty() {
+                isahc::Body::empty()
+            } else {
+                match body.len {
+                    Some(len) => isahc::Body::reader_sized(body, len),
+                    None => isahc::Body::reader(body),
+                }
             };
+
             let req: http::Request<isahc::Body> = http::Request::from_parts(parts, body);
 
             let res = client.send_async(req).await?;


### PR DESCRIPTION
SUMMARY:

Fixes the integration issue with isahc, whereby a `isahc::Body` created from
`isahc::Body::reader`has a length of `None`, which signals to `isahc::Client`
to send a body with an unknown length. A length of `None` is interpreted as
being unknown, and therefore a body is sent with every request. This causes a
501 error on servers which do not permit a body in the request, such as GET
requests to Cloudflare CDNs.

CHANGES:

* Changed `http_client::Body`'s `reader` field to being optional
* Added a `http_client::Body::is_empty` method to check for emptiness
* On creating a new request for `isahc::Client`:
  - Create a `isahc::Body::empty` if `http_client::Body` is empty
  - Create a `isahc::Body::reader` if otherwise not empty