### PR TITLE
Fix typo in wasm feature flag

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -3,5 +3,5 @@
 #[cfg(all(feature = "curl_client", not(target_arch = "wasm32")))]
 pub use super::isahc::IsahcClient as NativeClient;
 
-#[cfg(all(feature = "wasm-client", target_arch = "wasm32"))]
+#[cfg(all(feature = "wasm_client", target_arch = "wasm32"))]
 pub use super::wasm::WasmClient as NativeClient;


### PR DESCRIPTION
A typo in the wasm feature flag was preventing the `native` module from exporting `NativeClient`.

I'm currently working on fixing some compilation errors in `surf` when compiling for wasm, and this was one of the issues.