### PR TITLE
Add support for passing preconfigured isahc HttpClient instance.

### DIFF
--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -21,8 +21,13 @@ impl Default for IsahcClient {
 impl IsahcClient {
     /// Create a new instance.
     pub fn new() -> Self {
+        Self::from_client(isahc::HttpClient::new().unwrap())
+    }
+
+    /// Create from externally initialized and configured client.
+    pub fn from_client(client: isahc::HttpClient) -> Self {
         Self {
-            client: Arc::new(isahc::HttpClient::new().unwrap()),
+            client: Arc::new(client),
         }
     }
 }


### PR DESCRIPTION
This PR adds support to create an `IsahcClient` instance from a preconfigured `iashc::HttpClient` instance. This is important if one needs to tweak the client configuration.