### PR TITLE
Bugfix/#3 the wasm backend is not sending headers body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 [dependencies]
 futures = { version = "0.3.1", features = ["compat", "io-compat"] }
 http = "0.1.19"
-futures-util = "0.3.1"
 
 # isahc-client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -35,6 +34,7 @@ isahc = { version = "0.8", optional = true, default-features = false, features =
 js-sys = { version = "0.3.25", optional = true }
 wasm-bindgen = { version = "0.2.48", optional = true }
 wasm-bindgen-futures = { version = "0.4.5", optional = true }
+futures-util = "0.3.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"
@@ -54,6 +54,4 @@ features = [
     "Window",
 ]
 
-#https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/testing-your-project.html
 [dev-dependencies]
-wasm-bindgen-test = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 [dependencies]
 futures = { version = "0.3.1", features = ["compat", "io-compat"] }
 http = "0.1.19"
+futures-util = "0.3.1"
 
 # isahc-client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -53,4 +54,6 @@ features = [
     "Window",
 ]
 
+#https://rustwasm.github.io/docs/wasm-pack/tutorials/npm-browser-packages/testing-your-project.html
 [dev-dependencies]
+wasm-bindgen-test = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,8 +27,12 @@ use std::task::{Context, Poll};
 #[cfg(all(feature = "curl_client", not(target_arch = "wasm32")))]
 pub mod isahc;
 
+#[cfg_attr(feature = "docs", doc(cfg(wasm_client)))]
+#[cfg(all(feature = "wasm_client", target_arch = "wasm32"))]
 pub mod wasm;
 
+#[cfg_attr(feature = "docs", doc(cfg(native_client)))]
+#[cfg(feature = "native_client")]
 pub mod native;
 
 /// An HTTP Request type with a streaming body.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,12 +27,8 @@ use std::task::{Context, Poll};
 #[cfg(all(feature = "curl_client", not(target_arch = "wasm32")))]
 pub mod isahc;
 
-#[cfg_attr(feature = "docs", doc(cfg(wasm_client)))]
-#[cfg(all(feature = "wasm_client", target_arch = "wasm32"))]
 pub mod wasm;
 
-#[cfg_attr(feature = "docs", doc(cfg(native_client)))]
-#[cfg(feature = "native_client")]
 pub mod native;
 
 /// An HTTP Request type with a streaming body.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -52,7 +52,6 @@ impl HttpClient for WasmClient {
     }
 }
 
-// This type e
 struct InnerFuture {
     fut: Pin<Box<dyn Future<Output = Result<Response, io::Error>> + 'static>>,
 }
@@ -84,9 +83,9 @@ mod fetch {
     use web_sys::window;
     use web_sys::RequestInit;
 
-use std::pin::Pin;
     use std::io;
     use std::iter::{IntoIterator, Iterator};
+    use std::pin::Pin;
 
     /// Create a new fetch request.
     pub(crate) fn new(mut req: super::Request) -> Request {
@@ -128,7 +127,7 @@ use std::pin::Pin;
             init.headers(&init_headers);
 
             let mut body_buf = Vec::with_capacity(1024);
-            futures::executor::block_on(body.read_to_end(&mut  body_buf));
+            futures::executor::block_on(body.read_to_end(&mut body_buf));
             let body_pinned = Pin::new(body_buf);
 
             if body_pinned.len() > 0 {


### PR DESCRIPTION
resolves #3 

Currently pulls the whole body into an `Uint8Array`, because that seemed to be the only way to pass it through to js.

This is one of the first things I've written using rust futures, so apologies if it needs work.

Thanks for the fantastic library, I'm looking forward to demoing what I'm building with it :)