### PR TITLE
Make HTTPClient object safe

### DIFF
--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -1,6 +1,6 @@
 //! http-client implementation for isahc
 
-use super::{Body, HttpClient, Request, Response};
+use super::{Body, HttpClient, Request, Response, Error};
 
 use futures::future::BoxFuture;
 
@@ -41,9 +41,7 @@ impl Clone for IsahcClient {
 }
 
 impl HttpClient for IsahcClient {
-    type Error = isahc::Error;
-
-    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Self::Error>> {
+    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Error>> {
         let client = self.client.clone();
         Box::pin(async move {
             let (parts, body) = req.into_parts();

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -1,6 +1,6 @@
 //! http-client implementation for isahc
 
-use super::{Body, HttpClient, Request, Response, Error};
+use super::{Body, Error, HttpClient, Request, Response};
 
 use futures::future::BoxFuture;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 use futures::future::BoxFuture;
 use futures::io::{AsyncRead, Cursor};
 
-use std::error::Error;
 use std::fmt::{self, Debug};
 use std::io;
 use std::pin::Pin;
@@ -41,6 +40,9 @@ pub type Request = http::Request<Body>;
 /// An HTTP Response type with a streaming body.
 pub type Response = http::Response<Body>;
 
+/// An error returned by the HTTP backend
+pub type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
+
 /// An abstract HTTP client.
 ///
 /// __note that this is only exposed for use in middleware. Building new backing clients is not
@@ -55,12 +57,9 @@ pub type Response = http::Response<Body>;
 ///
 /// How `Clone` is implemented is up to the implementors, but in an ideal scenario combining this
 /// with the `Client` builder will allow for high connection reuse, improving latency.
-pub trait HttpClient: Debug + Unpin + Send + Sync + Clone + 'static {
-    /// The associated error type.
-    type Error: Error + Send + Sync;
-
+pub trait HttpClient: Debug + Unpin + Send + Sync + Clone + 'static + Sized {
     /// Perform a request.
-    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Self::Error>>;
+    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Error>>;
 }
 
 /// The raw body of an http request or response.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,6 @@
 //! http-client implementation for fetch
 
-use super::{Body, HttpClient, Request, Response, Error};
+use super::{Body, Error, HttpClient, Request, Response};
 
 use futures::future::BoxFuture;
 use futures::prelude::*;


### PR DESCRIPTION
* Adds the `Sized` bound to HTTPClient
* Removes the `Error` associated type and makes it dynamically
dispatched. This allows objects of the type `dyn HTTPClient` instead
of `dyn HTTPClient<ErrorType>`
* Makes both clients confirm with then new trait