### PR TITLE
feat: implement client for async-h1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ documentation = "https://docs.rs/http-client"
 description = "Types and traits for http clients."
 keywords = ["http", "service", "client", "futures", "async"]
 categories = ["asynchronous", "web-programming", "web-programming::http-client", "web-programming::websocket"]
-authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
+authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>", "dignifiedquire <me@dignifiedquire.com>"]
 readme = "README.md"
 edition = "2018"
 
@@ -16,18 +16,26 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-docs = ["native_client"]
+default = ["h1_client"]
+docs = ["h1_client"]
+h1_client = ["async-h1", "async-std", "async-native-tls"]
 native_client = ["curl_client", "wasm_client"]
 curl_client = ["isahc"]
 wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 
 [dependencies]
 futures = { version = "0.3.1", features = ["compat", "io-compat"] }
-http = "0.1.19"
+http-types = { version = "1.0.1", features = ["hyperium_http"] }
+log = "0.4.7"
+
+# h1-client
+async-h1 = { version = "1.0.0", optional = true }
+async-std = { version = "1.4.0", optional = true }
+async-native-tls = { version = "0.3.1", optional = true }
 
 # isahc-client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-isahc = { version = "0.8", optional = true, default-features = false, features = ["http2"]  }
+isahc = { version = "0.8", git = "https://github.com/sagebind/isahc", optional = true, default-features = false, features = ["http2"]  }
 
 # wasm-client
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["h1_client"]
 docs = ["h1_client"]
 h1_client = ["async-h1", "async-std", "async-native-tls"]
 native_client = ["curl_client", "wasm_client"]
-curl_client = ["isahc"]
+curl_client = ["isahc", "async-std"]
 wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 
 [dependencies]
@@ -30,12 +30,12 @@ log = "0.4.7"
 
 # h1-client
 async-h1 = { version = "1.0.0", optional = true }
-async-std = { version = "1.4.0", optional = true }
+async-std = { version = "1.4.0", default-features = false, optional = true }
 async-native-tls = { version = "0.3.1", optional = true }
 
 # isahc-client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-isahc = { version = "0.8", git = "https://github.com/sagebind/isahc", optional = true, default-features = false, features = ["http2"]  }
+isahc = { version = "0.9", optional = true, default-features = false, features = ["http2"]  }
 
 # wasm-client
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/h1.rs
+++ b/src/h1.rs
@@ -1,0 +1,80 @@
+//! http-client implementation for async-h1.
+
+use super::{HttpClient, Request, Response};
+
+use async_h1::client;
+use futures::future::BoxFuture;
+use http_types::{Error, StatusCode};
+
+/// Async-h1 based HTTP Client.
+#[derive(Debug)]
+pub struct H1Client {}
+
+impl Default for H1Client {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl H1Client {
+    /// Create a new instance.
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Clone for H1Client {
+    fn clone(&self) -> Self {
+        Self {}
+    }
+}
+
+impl HttpClient for H1Client {
+    type Error = Error;
+
+    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Self::Error>> {
+        Box::pin(async move {
+            // Insert host
+            let host = req
+                .url()
+                .host_str()
+                .ok_or_else(|| Error::from_str(StatusCode::BadRequest, "missing hostname"))?;
+
+            let scheme = req.url().scheme();
+            if scheme != "http" && scheme != "https" {
+                return Err(Error::from_str(
+                    StatusCode::BadRequest,
+                    format!("invalid url scheme '{}'", scheme),
+                ));
+            }
+
+            let addr = req
+                .url()
+                .socket_addrs(|| match req.url().scheme() {
+                    "http" => Some(80),
+                    "https" => Some(443),
+                    _ => None,
+                })?
+                .into_iter()
+                .next()
+                .ok_or_else(|| Error::from_str(StatusCode::BadRequest, "missing valid address"))?;
+
+            log::trace!("> Scheme: {}", scheme);
+
+            match scheme {
+                "http" => {
+                    let stream = async_std::net::TcpStream::connect(addr).await?;
+                    client::connect(stream, req).await
+                }
+                "https" => {
+                    let raw_stream = async_std::net::TcpStream::connect(addr).await?;
+
+                    let stream = async_native_tls::connect(host, raw_stream).await?;
+
+                    client::connect(stream, req).await
+                }
+                _ => unreachable!(),
+            }
+        })
+    }
+}

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -2,6 +2,7 @@
 
 use super::{Body, HttpClient, Request, Response};
 
+use async_std::io::BufReader;
 use futures::future::BoxFuture;
 use isahc::http;
 
@@ -59,12 +60,10 @@ impl HttpClient for IsahcClient {
 
             let (parts, body) = res.into_parts();
 
-            // FIXME: isahc::Body is !Sync, making it impossible to pass to http::Response
-            unimplemented!();
-
-            // let body = Body::from_reader(body, body.len().map(|len| len as usize));
-            // let res = http::Response::from_parts(parts, body);
-            // Ok(res.into())
+            let len = body.len().map(|len| len as usize);
+            let body = Body::from_reader(BufReader::new(body), len);
+            let res = http::Response::from_parts(parts, body);
+            Ok(res.into())
         })
     }
 }

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -3,6 +3,7 @@
 use super::{Body, HttpClient, Request, Response};
 
 use futures::future::BoxFuture;
+use isahc::http;
 
 use std::sync::Arc;
 
@@ -46,25 +47,24 @@ impl HttpClient for IsahcClient {
     fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Self::Error>> {
         let client = self.client.clone();
         Box::pin(async move {
-            let (parts, body) = req.into_parts();
-
-            let body = if body.is_empty() {
-                isahc::Body::empty()
-            } else {
-                match body.len {
-                    Some(len) => isahc::Body::reader_sized(body, len),
-                    None => isahc::Body::reader(body),
-                }
+            let req_hyperium: http::Request<http_types::Body> = req.into();
+            let (parts, body) = req_hyperium.into_parts();
+            let body = match body.len() {
+                Some(len) => isahc::Body::from_reader_sized(body, len as u64),
+                None => isahc::Body::from_reader(body),
             };
-
             let req: http::Request<isahc::Body> = http::Request::from_parts(parts, body);
 
             let res = client.send_async(req).await?;
 
             let (parts, body) = res.into_parts();
-            let body = Body::from_reader(body);
-            let res = http::Response::from_parts(parts, body);
-            Ok(res)
+
+            // FIXME: isahc::Body is !Sync, making it impossible to pass to http::Response
+            unimplemented!();
+
+            // let body = Body::from_reader(body, body.len().map(|len| len as usize));
+            // let res = http::Response::from_parts(parts, body);
+            // Ok(res.into())
         })
     }
 }


### PR DESCRIPTION
- Switches to uses `http-types`
- Implement client using `async-h1`
- Currently this breaks the isahc client, as `isahc::Body` is not `Sync`