### PR TITLE
Upgrade isahc to 0.9 and http to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,11 @@ wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 
 [dependencies]
 futures = { version = "0.3.1", features = ["compat", "io-compat"] }
-http = "0.1.19"
+http = "0.2.1"
 
 # isahc-client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-isahc = { version = "0.8", optional = true, default-features = false, features = ["http2"]  }
+isahc = { version = "0.9", optional = true, default-features = false, features = ["http2"]  }
 
 # wasm-client
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -52,8 +52,8 @@ impl HttpClient for IsahcClient {
                 isahc::Body::empty()
             } else {
                 match body.len {
-                    Some(len) => isahc::Body::reader_sized(body, len),
-                    None => isahc::Body::reader(body),
+                    Some(len) => isahc::Body::from_reader_sized(body, len),
+                    None => isahc::Body::from_reader(body),
                 }
             };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub trait HttpClient: Debug + Unpin + Send + Sync + Clone + 'static {
 /// Both `Body` and `Bytes` values can be easily created from standard owned byte buffer types
 /// like `Vec<u8>` or `String`, using the `From` trait.
 pub struct Body {
-    reader: Option<Box<dyn AsyncRead + Unpin + Send + 'static>>,
+    reader: Option<Box<dyn AsyncRead + Unpin + Send + Sync + 'static>>,
     /// Intentionally use `u64` over `usize` here.
     /// `usize` won't work if you try to send 10GB file from 32bit host.
     #[allow(dead_code)] // not all backends make use of this
@@ -86,7 +86,7 @@ impl Body {
     }
 
     /// Create a new instance from a reader.
-    pub fn from_reader(reader: impl AsyncRead + Unpin + Send + 'static) -> Self {
+    pub fn from_reader(reader: impl AsyncRead + Unpin + Send + Sync + 'static) -> Self {
         Self {
             reader: Some(Box::new(reader)),
             len: None,
@@ -132,7 +132,7 @@ impl From<Vec<u8>> for Body {
     }
 }
 
-impl<R: AsyncRead + Unpin + Send + 'static> From<Box<R>> for Body {
+impl<R: AsyncRead + Unpin + Send + Sync + 'static> From<Box<R>> for Body {
     /// Converts an `AsyncRead` into a Body.
     #[allow(missing_doc_code_examples)]
     fn from(reader: Box<R>) -> Self {


### PR DESCRIPTION
This is needed to [update Surf to use isahc 0.9](https://github.com/http-rs/surf/issues/153), I believe it first necessary to update http-client to use http 0.2 and isahc 0.9.

My approach here was fairly naive. I read the changelog for the two libraries, and then updated the files in `Cargo.toml` and made changes until it compiled. It's quite possible I've missed something.

Once this change is released, I have a similar patch for Surf as well.