### PR TITLE
Fix wasm compilation and send body and headers from WasmClient

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,3 +65,23 @@ jobs:
 
     - name: Docs
       run: cargo doc
+
+  check_wasm:
+    name: Check wasm targets
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Install nightly with wasm32-unknown-unknown
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        target: wasm32-unknown-unknown
+        override: true
+
+    - name: check
+      uses: actions-rs/cargo@v1
+      with:
+        command: check
+        args: --target wasm32-unknown-unknown --no-default-features --features "native_client,wasm_client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 
 [dependencies]
 futures = { version = "0.3.1" }
-http-types = "2.0.1"
+http-types = "2.1.0"
 log = "0.4.7"
 
 # h1-client

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ isahc = { version = "0.9", optional = true, default-features = false, features =
 js-sys = { version = "0.3.25", optional = true }
 wasm-bindgen = { version = "0.2.48", optional = true }
 wasm-bindgen-futures = { version = "0.4.5", optional = true }
-futures-util = "0.3.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 
 [dependencies]
 futures = { version = "0.3.1" }
-http-types = "2.1.0"
+http-types = "2.2.1"
 log = "0.4.7"
 
 # h1-client

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures"]
 
 [dependencies]
 futures = { version = "0.3.1" }
-http-types = "2.2.1"
+http-types = "2.3.0"
 log = "0.4.7"
 
 # h1-client

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ isahc = { version = "0.9", optional = true, default-features = false, features =
 js-sys = { version = "0.3.25", optional = true }
 wasm-bindgen = { version = "0.2.48", optional = true }
 wasm-bindgen-futures = { version = "0.4.5", optional = true }
+futures-util = "0.3.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -43,10 +43,7 @@ impl HttpClient for WasmClient {
             response.set_body(Body::from(body));
             for (name, value) in res.headers() {
                 let name: http_types::headers::HeaderName = name.parse().unwrap();
-                response.insert_header(
-                    &name,
-                    value.parse::<http_types::headers::HeaderValue>().unwrap(),
-                );
+                response.insert_header(&name, value);
             }
 
             Ok(response)
@@ -76,7 +73,6 @@ impl Future for InnerFuture {
 }
 
 mod fetch {
-    use futures_util::io::AsyncReadExt;
     use js_sys::{Array, ArrayBuffer, Reflect, Uint8Array};
     use wasm_bindgen::JsCast;
     use wasm_bindgen_futures::JsFuture;
@@ -91,35 +87,34 @@ mod fetch {
     /// An HTTP Fetch Request.
     pub(crate) struct Request {
         request: web_sys::Request,
-        _body_buf: Pin<Vec<u8>>,
+        /// This field stores the body of the request to ensure it stays allocated as long as the request needs it.
+        #[allow(dead_code)]
+        body_buf: Pin<Vec<u8>>,
     }
 
     impl Request {
         /// Create a new instance.
         pub(crate) async fn new(mut req: super::Request) -> Result<Self, io::Error> {
-            //create a fetch request initaliser
+            // create a fetch request initaliser
             let mut init = RequestInit::new();
 
-            //set the fetch method
+            // set the fetch method
             init.method(req.method().as_ref());
 
             let uri = req.url().to_string();
-            let mut body = req.take_body();
+            let body = req.take_body();
 
-            //convert the body into a uint8 array
+            // convert the body into a uint8 array
             // needs to be pinned and retained inside the Request because the Uint8Array passed to
             // js is just a portal into WASM linear memory, and if the underlying data is moved the
             // js ref will become silently invalid
-            let mut body_buf = Vec::with_capacity(1024);
-            body.read_to_end(&mut body_buf).await.map_err(|_| {
+            let body_buf = body.into_bytes().await.map_err(|_| {
                 io::Error::new(io::ErrorKind::Other, "could not read body into a buffer")
             })?;
             let body_pinned = Pin::new(body_buf);
             if body_pinned.len() > 0 {
-                unsafe {
-                    let uint_8_array = js_sys::Uint8Array::view(&body_pinned);
-                    init.body(Some(&uint_8_array));
-                }
+                let uint_8_array = unsafe { js_sys::Uint8Array::view(&body_pinned) };
+                init.body(Some(&uint_8_array));
             }
 
             let request = web_sys::Request::new_with_str_and_init(&uri, &init).map_err(|e| {
@@ -129,7 +124,7 @@ mod fetch {
                 )
             })?;
 
-            //add any fetch headers
+            // add any fetch headers
             let headers: &mut super::Headers = req.as_mut();
             for (name, value) in headers.iter() {
                 let name = name.as_str();
@@ -145,7 +140,7 @@ mod fetch {
 
             Ok(Self {
                 request,
-                _body_buf: body_pinned,
+                body_buf: body_pinned,
             })
         }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -5,6 +5,7 @@ use super::{Body, HttpClient, Request, Response};
 use futures::future::BoxFuture;
 use futures::prelude::*;
 
+use std::convert::TryFrom;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -33,17 +34,19 @@ impl HttpClient for WasmClient {
 
     fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Self::Error>> {
         let fut = Box::pin(async move {
-            let url = format!("{}", req.uri());
-            let req = fetch::new(req.method().as_str(), &url);
+            let req = fetch::new(req.method(), req.url());
             let mut res = req.send().await?;
 
             let body = res.body_bytes();
-            let mut response = Response::new(Body::from(body));
-            *response.status_mut() = http::StatusCode::from_u16(res.status()).unwrap();
-
+            let mut response =
+                Response::new(http_types::StatusCode::try_from(res.status()).unwrap());
+            response.set_body(Body::from(body));
             for (name, value) in res.headers() {
-                let name: http::header::HeaderName = name.parse().unwrap();
-                response.headers_mut().insert(name, value.parse().unwrap());
+                let name: http_types::headers::HeaderName = name.parse().unwrap();
+                response.insert_header(
+                    &name,
+                    value.parse::<http_types::headers::HeaderValue>().unwrap(),
+                );
             }
 
             Ok(response)

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -34,7 +34,7 @@ impl HttpClient for WasmClient {
 
     fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Self::Error>> {
         let fut = Box::pin(async move {
-            let req = fetch::new(req.method(), req.url());
+            let req: fetch::Request = fetch::Request::new(req)?;
             let mut res = req.send().await?;
 
             let body = res.body_bytes();
@@ -56,7 +56,6 @@ impl HttpClient for WasmClient {
     }
 }
 
-// This type e
 struct InnerFuture {
     fut: Pin<Box<dyn Future<Output = Result<Response, io::Error>> + 'static>>,
 }
@@ -77,6 +76,8 @@ impl Future for InnerFuture {
 }
 
 mod fetch {
+    use futures_util::io::AsyncReadExt;
+    use http::request::Parts;
     use js_sys::{Array, ArrayBuffer, Reflect, Uint8Array};
     use wasm_bindgen::JsCast;
     use wasm_bindgen_futures::JsFuture;
@@ -85,27 +86,75 @@ mod fetch {
 
     use std::io;
     use std::iter::{IntoIterator, Iterator};
+    use std::pin::Pin;
 
     /// Create a new fetch request.
-    pub(crate) fn new(method: impl AsRef<str>, url: impl AsRef<str>) -> Request {
-        Request::new(method, url)
-    }
 
     /// An HTTP Fetch Request.
     pub(crate) struct Request {
         init: RequestInit,
         url: String,
+        _body_buf: Pin<Vec<u8>>,
     }
 
     impl Request {
         /// Create a new instance.
-        pub(crate) fn new(method: impl AsRef<str>, url: impl AsRef<str>) -> Self {
+        pub(crate) fn new(req: super::Request) -> Result<Self, io::Error> {
+            let (
+                Parts {
+                    method,
+                    uri,
+                    headers,
+                    ..
+                },
+                mut body,
+            ) = req.into_parts();
+
+            //create a fetch request initaliser
             let mut init = web_sys::RequestInit::new();
+
+            //set the fetch method
             init.method(method.as_ref());
-            Self {
-                init,
-                url: url.as_ref().to_owned(),
+
+            //add any fetch headers
+            let init_headers = web_sys::Headers::new().unwrap();
+            for (name, value) in headers.iter() {
+                init_headers
+                    .append(name.as_str(), value.to_str().unwrap())
+                    .map_err(|_| {
+                        io::Error::new(
+                            io::ErrorKind::Other,
+                            format!(
+                                "could not add header: {} = {}",
+                                name.as_str(),
+                                value.to_str().expect("could not stringify header value")
+                            ),
+                        )
+                    })?;
             }
+            init.headers(&init_headers);
+
+            //convert the body into a uint8 array
+            // needs to be pinned and retained inside the Request because the Uint8Array passed to
+            // js is just a portal into WASM linear memory, and if the underlying data is moved the
+            // js ref will become silently invalid
+            let mut body_buf = Vec::with_capacity(1024);
+            futures::executor::block_on(body.read_to_end(&mut body_buf)).map_err(|_| {
+                io::Error::new(io::ErrorKind::Other, "could not read body into a buffer")
+            })?;
+            let body_pinned = Pin::new(body_buf);
+            if body_pinned.len() > 0 {
+                unsafe {
+                    let uint_8_array = js_sys::Uint8Array::view(&body_pinned);
+                    init.body(Some(&uint_8_array));
+                }
+            }
+
+            Ok(Self {
+                init,
+                url: uri.to_string(),
+                _body_buf: body_pinned,
+            })
         }
 
         /// Submit a request


### PR DESCRIPTION
Fix wasm compilation

* Upgrade to http-types v2.3.0 to get the wasm compilation fix
* Add CI job to check compilation on wasm32-unknown-unknown
* Closes #3 