### PR TITLE
HttpClient: remove Error type bounds

### DIFF
--- a/src/h1.rs
+++ b/src/h1.rs
@@ -1,10 +1,10 @@
 //! http-client implementation for async-h1.
 
-use super::{HttpClient, Request, Response};
+use super::{Error, HttpClient, Request, Response};
 
 use async_h1::client;
 use futures::future::BoxFuture;
-use http_types::{Error, StatusCode};
+use http_types::StatusCode;
 
 /// Async-h1 based HTTP Client.
 #[derive(Debug)]
@@ -30,9 +30,7 @@ impl Clone for H1Client {
 }
 
 impl HttpClient for H1Client {
-    type Error = Error;
-
-    fn send(&self, mut req: Request) -> BoxFuture<'static, Result<Response, Self::Error>> {
+    fn send(&self, mut req: Request) -> BoxFuture<'static, Result<Response, Error>> {
         Box::pin(async move {
             // Insert host
             let host = req

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,11 +53,8 @@ pub use http_types;
 /// though middleware for one of its own requests, and in order to do so should be wrapped in an
 /// `Rc`/`Arc` to enable reference cloning.
 pub trait HttpClient: std::fmt::Debug + Unpin + Send + Sync + 'static {
-    /// The associated error type.
-    type Error: Send + Sync + Into<Error>;
-
     /// Perform a request.
-    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Self::Error>>;
+    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Error>>;
 }
 
 /// The raw body of an http request or response.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,6 +1,6 @@
 //! http-client implementation for fetch
 
-use super::{Body, HttpClient, Request, Response};
+use super::{Body, Error, HttpClient, Request, Response};
 
 use futures::future::BoxFuture;
 use futures::prelude::*;
@@ -29,9 +29,7 @@ impl Clone for WasmClient {
 }
 
 impl HttpClient for WasmClient {
-    type Error = std::io::Error;
-
-    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Self::Error>> {
+    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Error>> {
         let fut = Box::pin(async move {
             let url = format!("{}", req.uri());
             let req = fetch::new(req.method().as_str(), &url);


### PR DESCRIPTION
This makes using HttpClient as a dynamic Trait object, such as in
https://github.com/http-rs/surf/issues/69
substantially more complex.

This complexity can be reduced by having the backing client implementor handle the error translation (which was already required to begin with).