### PR TITLE
HttpClient: remove Clone bounds, ensure unsized

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,14 +47,12 @@ pub use http_types;
 /// trait from there together with all existing HTTP client implementations.__
 ///
 /// ## Spawning new request from middleware
-/// When threading the trait through a layer of middleware, the middleware must be able to perform
-/// new requests. In order to enable this we pass an `HttpClient` instance through the middleware,
-/// with a `Clone` implementation. In order to spawn a new request, `clone` is called, and a new
-/// request is enabled.
 ///
-/// How `Clone` is implemented is up to the implementors, but in an ideal scenario combining this
-/// with the `Client` builder will allow for high connection reuse, improving latency.
-pub trait HttpClient: std::fmt::Debug + Unpin + Send + Sync + Clone + 'static {
+/// When threading the trait through a layer of middleware, the middleware must be able to perform
+/// new requests. In order to enable this efficiently an `HttpClient` instance may want to be passed
+/// though middleware for one of its own requests, and in order to do so should be wrapped in an
+/// `Rc`/`Arc` to enable reference cloning.
+pub trait HttpClient: std::fmt::Debug + Unpin + Send + Sync + 'static {
     /// The associated error type.
     type Error: Send + Sync + Into<Error>;
 


### PR DESCRIPTION
This allows `HttpClient` to be used as a dynamic Trait Object, which requires that the trait not have the `Sized` bounds, which was implied by `Clone`.

Users should wrap `HttpClient` in an `Rc`/`Arc` if Cloning/Sharing is necessary.

------

This fixes the original issue from https://github.com/http-rs/surf/issues/69. _(https://github.com/http-rs/http-client/pull/29 fixes a newer issue.)_

This supersedes https://github.com/http-rs/http-client/pull/18 as that patch is the opposite, which was already implied by `Clone` and is incorrect.
This also supersedes the same faulty patch part from https://github.com/http-rs/http-client/pull/21.