### PR TITLE
CI: run fmt & docs on nightly for #[feature]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,11 +52,11 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: Install stable toolchain
+    - name: Install nightly toolchain
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: stable
+        toolchain: nightly
         override: true
         components: rustfmt
 


### PR DESCRIPTION
Required to make PR CI green again. Surf also uses nightly for this.