### PR TITLE
Replace the native-client feature gate around the native module with its component features

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub mod isahc;
 pub mod wasm;
 
 #[cfg_attr(feature = "docs", doc(cfg(native_client)))]
-#[cfg(feature = "native_client")]
+#[cfg(any(feature = "curl_client", feature = "wasm_client"))]
 pub mod native;
 
 #[cfg_attr(feature = "docs", doc(cfg(h1_client)))]


### PR DESCRIPTION
Previously it was not possible to compile http-client with just the curl or wasm feature enabled and still use the native module. This is useful for higher level libraries like surf where someone may want to gate wasm/curl features separately instead of bundled together. A companion PR for surf (https://github.com/http-rs/surf/pull/214) fixes a similar issue.