### PR TITLE
Switch to using async_trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ async-native-tls = { version = "0.3.1", optional = true }
 # reqwest-client
 hyper = { version = "0.13.6", features = ["tcp"], optional = true }
 hyper-tls = { version = "0.4.3", optional = true }
+async-trait = "0.1.37"
 
 # isahc-client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -1,9 +1,8 @@
 //! http-client implementation for isahc
 
-use super::{Body, Error, HttpClient, Request, Response};
+use super::{async_trait, Body, Error, HttpClient, Request, Response};
 
 use async_std::io::BufReader;
-use futures::future::BoxFuture;
 use isahc::http;
 use std::sync::Arc;
 
@@ -41,8 +40,9 @@ impl Clone for IsahcClient {
     }
 }
 
+#[async_trait]
 impl HttpClient for IsahcClient {
-    fn send(&self, mut req: Request) -> BoxFuture<'static, Result<Response, Error>> {
+    async fn send(&self, mut req: Request) -> Result<Response, Error> {
         let client = self.client.clone();
         Box::pin(async move {
             let mut builder = http::Request::builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@
     forbid(unsafe_code)
 )]
 
-use futures::future::BoxFuture;
-
 #[cfg_attr(feature = "docs", doc(cfg(curl_client)))]
 #[cfg(all(feature = "curl_client", not(target_arch = "wasm32")))]
 pub mod isahc;
@@ -42,6 +40,7 @@ pub type Request = http_types::Request;
 /// An HTTP Response type with a streaming body.
 pub type Response = http_types::Response;
 
+pub use async_trait::async_trait;
 pub use http_types;
 
 /// An abstract HTTP client.
@@ -56,9 +55,10 @@ pub use http_types;
 /// new requests. In order to enable this efficiently an `HttpClient` instance may want to be passed
 /// though middleware for one of its own requests, and in order to do so should be wrapped in an
 /// `Rc`/`Arc` to enable reference cloning.
+#[async_trait]
 pub trait HttpClient: std::fmt::Debug + Unpin + Send + Sync + 'static {
     /// Perform a request.
-    fn send(&self, req: Request) -> BoxFuture<'static, Result<Response, Error>>;
+    async fn send(&self, req: Request) -> Result<Response, Error>;
 }
 
 /// The raw body of an http request or response.


### PR DESCRIPTION
I went to implement HttpClient for tide::Server and noticed that this was using BoxFuture instead of async_trait. This PR switches to async_trait. I'm not entirely sure if this is a breaking change

The wasm implementation is a little awkward because it wasn't just returning an anonymous `Box::pin(async move {})`, but as a tradeoff, other implementations are easier to read