### PR TITLE
Fix link to releases in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
       API Docs
     </a>
     <span> | </span>
-    <a href="https://github.com/async-rs/async-std/releases">
+    <a href="https://github.com/http-rs/http-client/releases">
       Releases
     </a>
     <span> | </span>


### PR DESCRIPTION
It took me a while to realize I was looking at async-std releases, not http-client ones. :)