### PR TITLE
src: require Clone for HttpClient

### DIFF
--- a/src/hyper.rs
+++ b/src/hyper.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::str::FromStr;
 
 /// Hyper-based HTTP Client.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct HyperClient {}
 
 impl HyperClient {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ pub use http_types;
 /// though middleware for one of its own requests, and in order to do so should be wrapped in an
 /// `Rc`/`Arc` to enable reference cloning.
 #[async_trait]
-pub trait HttpClient: std::fmt::Debug + Unpin + Send + Sync + 'static {
+pub trait HttpClient: Clone + std::fmt::Debug + Unpin + Send + Sync + 'static {
     /// Perform a request.
     async fn send(&self, req: Request) -> Result<Response, Error>;
 }


### PR DESCRIPTION
This was largely already the case, just not enforced.

Fixes: https://github.com/http-rs/http-client/issues/46
Refs: https://github.com/http-rs/surf/issues/237