### PR TITLE
No Clone for HttpClient-s

### DIFF
--- a/src/h1.rs
+++ b/src/h1.rs
@@ -7,7 +7,9 @@ use http_types::StatusCode;
 
 /// Async-h1 based HTTP Client.
 #[derive(Debug)]
-pub struct H1Client {}
+pub struct H1Client {
+    _priv: (),
+}
 
 impl Default for H1Client {
     fn default() -> Self {
@@ -18,7 +20,7 @@ impl Default for H1Client {
 impl H1Client {
     /// Create a new instance.
     pub fn new() -> Self {
-        Self {}
+        Self { _priv: () }
     }
 }
 

--- a/src/h1.rs
+++ b/src/h1.rs
@@ -22,12 +22,6 @@ impl H1Client {
     }
 }
 
-impl Clone for H1Client {
-    fn clone(&self) -> Self {
-        Self {}
-    }
-}
-
 #[async_trait]
 impl HttpClient for H1Client {
     async fn send(&self, mut req: Request) -> Result<Response, Error> {

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -4,13 +4,10 @@ use super::{async_trait, Body, Error, HttpClient, Request, Response};
 
 use async_std::io::BufReader;
 use isahc::http;
-use std::sync::Arc;
 
 /// Curl-based HTTP Client.
 #[derive(Debug)]
-pub struct IsahcClient {
-    client: Arc<isahc::HttpClient>,
-}
+pub struct IsahcClient(isahc::HttpClient);
 
 impl Default for IsahcClient {
     fn default() -> Self {
@@ -26,17 +23,7 @@ impl IsahcClient {
 
     /// Create from externally initialized and configured client.
     pub fn from_client(client: isahc::HttpClient) -> Self {
-        Self {
-            client: Arc::new(client),
-        }
-    }
-}
-
-impl Clone for IsahcClient {
-    fn clone(&self) -> Self {
-        Self {
-            client: self.client.clone(),
-        }
+        Self(client)
     }
 }
 
@@ -59,7 +46,7 @@ impl HttpClient for IsahcClient {
         };
 
         let request = builder.body(body).unwrap();
-        let res = self.client.send_async(request).await.map_err(Error::from)?;
+        let res = self.0.send_async(request).await.map_err(Error::from)?;
         let (parts, body) = res.into_parts();
         let len = body.len().map(|len| len as usize);
         let body = Body::from_reader(BufReader::new(body), len);

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -21,12 +21,6 @@ impl WasmClient {
     }
 }
 
-impl Clone for WasmClient {
-    fn clone(&self) -> Self {
-        Self { _priv: () }
-    }
-}
-
 impl HttpClient for WasmClient {
     fn send<'a, 'async_trait>(
         &'a self,


### PR DESCRIPTION
~~_(Based on https://github.com/http-rs/http-client/pull/45 for future simplicity.)_~~

An alternate to https://github.com/http-rs/http-client/pull/47 "src: require Clone for HttpClient", this PR removes `Clone` impls from all `HttpClient`s.

This is an alternate to the bottom part of https://github.com/http-rs/surf/issues/237 / https://github.com/http-rs/http-client/issues/46

The idea is to avoid multiple `Arc`s, and this pushes the responsibility for sharing a client to the upper client, i.e. Surf. Surf already has to have a pointer for every client anyways, so as to hide the generic from its `Client` definition.
