### PR TITLE
add an implementation of HttpClient for Box<dyn HttpClient>

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,3 +66,10 @@ pub type Body = http_types::Body;
 
 /// Error type.
 pub type Error = http_types::Error;
+
+#[async_trait]
+impl HttpClient for Box<dyn HttpClient> {
+    async fn send(&self, req: Request) -> Result<Response, Error> {
+        self.send(req).await
+    }
+}


### PR DESCRIPTION
I ran into this with the following code:

```rust
let http_client: Box<dyn HttpClient> = match self.client {
    H1 => Box::new(H1Client::new()),
    Curl => Box::new(IsahcClient::new()),
    Hyper => Box::new(HyperClient::new()),
};
let client = surf::Client::with_http_client(http_client); // won't compile without this PR
```