### PR TITLE
fix a mistake in the Box<dyn HttpClient> implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,6 @@ pub type Error = http_types::Error;
 #[async_trait]
 impl HttpClient for Box<dyn HttpClient> {
     async fn send(&self, req: Request) -> Result<Response, Error> {
-        self.send(req).await
+        self.as_ref().send(req).await
     }
 }


### PR DESCRIPTION
without the .as_ref(), it recursed infinitely because self is the Box, not the dyn HttpClient 🤦 