### PR TITLE
Add 'h1_client_rustls' feature using 'async-tls'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 default = ["h1_client"]
 docs = ["h1_client"]
 h1_client = ["async-h1", "async-std", "async-native-tls"]
+h1_client_rustls = ["async-h1", "async-std", "async-tls"]
 native_client = ["curl_client", "wasm_client"]
 curl_client = ["isahc", "async-std"]
 wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures", "futures"]
@@ -37,6 +38,9 @@ log = "0.4.7"
 async-h1 = { version = "2.0.0", optional = true }
 async-std = { version = "1.6.0", default-features = false, optional = true }
 async-native-tls = { version = "0.3.1", optional = true }
+
+# h1_client_rustls
+async-tls = { version = "0.10.0", optional = true }
 
 # hyper_client
 hyper = { version = "0.13.6", features = ["tcp"], optional = true }
@@ -76,5 +80,7 @@ features = [
 [dev-dependencies]
 async-std = { version = "1.6.0", features = ["unstable", "attributes"] }
 portpicker = "0.1.0"
-tide = { version = "0.13.0" }
+tide = { version = "0.15.0" }
+tide-rustls = { version = "0.1.4" }
 tokio = { version = "0.2.21", features = ["macros"] }
+serde_json = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ pub mod wasm;
 pub mod native;
 
 #[cfg_attr(feature = "docs", doc(cfg(h1_client)))]
-#[cfg(feature = "h1_client")]
+#[cfg(any(feature = "h1_client", feature = "h1_client_rustls"))]
 pub mod h1;
 
 #[cfg_attr(feature = "docs", doc(cfg(hyper_client)))]


### PR DESCRIPTION
Following discussions in http-rs/surf#40 and http-rs/surf#43, here my proposal to add a `"h1_client_rustls"` feature.

It makes http-client to depend on **async-tls** instead of **async-native-tls**. It seems to work fine according to the `https_functionality()` test I added in h1.rs.   
The only inconvenient I see now is that the default feature (`"h1_client"`) must be explicitly deactivated to avoid dependency to async-native-tls. I don't know if it's possible to make Cargo automatically deactivate `"h1_client"` if `"h1_client_rustls"` is active.