### PR TITLE
feat: h1 connection pooling 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 [features]
 default = ["h1_client"]
 docs = ["h1_client", "curl_client", "wasm_client", "hyper_client"]
-h1_client = ["async-h1", "async-std", "async-native-tls"]
-h1_client_rustls = ["async-h1", "async-std", "async-tls"]
+h1_client = ["async-h1", "async-std", "async-native-tls", "deadpool", "futures"]
+h1_client_rustls = ["async-h1", "async-std", "async-tls", "deadpool", "futures"]
 native_client = ["curl_client", "wasm_client"]
 curl_client = ["isahc", "async-std"]
 wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures", "futures"]
@@ -38,6 +38,8 @@ log = "0.4.7"
 async-h1 = { version = "2.0.0", optional = true }
 async-std = { version = "1.6.0", default-features = false, optional = true }
 async-native-tls = { version = "0.3.1", optional = true }
+deadpool = { version = "0.6.0", optional = true }
+futures = { version = "0.3.8", optional = true }
 
 # h1_client_rustls
 async-tls = { version = "0.10.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ log = "0.4.7"
 async-h1 = { version = "2.0.0", optional = true }
 async-std = { version = "1.6.0", default-features = false, optional = true }
 async-native-tls = { version = "0.3.1", optional = true }
-deadpool = { version = "0.6.0", optional = true }
+deadpool = { version = "0.7.0", optional = true }
 futures = { version = "0.3.8", optional = true }
 
 # h1_client_rustls

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ hyper_client = ["hyper", "hyper-tls", "http-types/hyperium_http", "futures-util"
 
 [dependencies]
 async-trait = "0.1.37"
-dashmap = "3.11.10"
+dashmap = "4.0.2"
 http-types = "2.3.0"
 log = "0.4.7"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ hyper_client = ["hyper", "hyper-tls", "http-types/hyperium_http", "futures-util"
 
 [dependencies]
 async-trait = "0.1.37"
+dashmap = "3.11.10"
 http-types = "2.3.0"
 log = "0.4.7"
 

--- a/src/h1/mod.rs
+++ b/src/h1/mod.rs
@@ -132,7 +132,10 @@ impl HttpClient for H1Client {
                     self.https_pools.get(&addr).unwrap()
                 };
                 let pool = pool.clone();
-                let stream = pool.get().await.unwrap(); // TODO: remove unwrap
+                let stream = pool
+                    .get()
+                    .await
+                    .map_err(|e| Error::from_str(400, e.to_string()))?;
                 req.set_peer_addr(stream.get_ref().peer_addr().ok());
                 req.set_local_addr(stream.get_ref().local_addr().ok());
 

--- a/src/h1/mod.rs
+++ b/src/h1/mod.rs
@@ -106,11 +106,6 @@ impl HttpClient for H1Client {
                 req.set_peer_addr(stream.peer_addr().ok());
                 req.set_local_addr(stream.local_addr().ok());
                 client::connect(TcpConnWrapper::new(stream), req).await
-
-                // let stream = async_std::net::TcpStream::connect(addr).await?;
-                // req.set_peer_addr(stream.peer_addr().ok());
-                // req.set_local_addr(stream.local_addr().ok());
-                // client::connect(stream, req).await
             }
             "https" => {
                 let pool = if let Some(pool) = self.https_pools.get(&addr) {
@@ -130,14 +125,6 @@ impl HttpClient for H1Client {
                 req.set_local_addr(stream.get_ref().local_addr().ok());
 
                 client::connect(TlsConnWrapper::new(stream), req).await
-
-                // let raw_stream = async_std::net::TcpStream::connect(addr).await?;
-                // req.set_peer_addr(raw_stream.peer_addr().ok());
-                // req.set_local_addr(raw_stream.local_addr().ok());
-
-                // let stream = async_native_tls::connect(host, raw_stream).await?;
-
-                // client::connect(stream, req).await
             }
             _ => unreachable!(),
         }

--- a/src/h1/tcp.rs
+++ b/src/h1/tcp.rs
@@ -43,8 +43,7 @@ impl AsyncWrite for TcpConnWrapper {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        let amt = futures::ready!(Pin::new(&mut *self.conn).poll_write(cx, buf))?;
-        Poll::Ready(Ok(amt))
+        Pin::new(&mut *self.conn).poll_write(cx, buf)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {

--- a/src/h1/tcp.rs
+++ b/src/h1/tcp.rs
@@ -1,0 +1,68 @@
+use std::fmt::Debug;
+use std::net::SocketAddr;
+use std::pin::Pin;
+
+use async_std::net::TcpStream;
+use async_trait::async_trait;
+use deadpool::managed::{Manager, Object, RecycleResult};
+use futures::io::{AsyncRead, AsyncWrite};
+use futures::task::{Context, Poll};
+
+#[derive(Clone, Debug)]
+pub(crate) struct TcpConnection {
+    addr: SocketAddr,
+}
+impl TcpConnection {
+    pub(crate) fn new(addr: SocketAddr) -> Self {
+        Self { addr }
+    }
+}
+
+pub(crate) struct TcpConnWrapper {
+    conn: Object<TcpStream, std::io::Error>,
+}
+impl TcpConnWrapper {
+    pub(crate) fn new(conn: Object<TcpStream, std::io::Error>) -> Self {
+        Self { conn }
+    }
+}
+
+impl AsyncRead for TcpConnWrapper {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut *self.conn).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for TcpConnWrapper {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let amt = futures::ready!(Pin::new(&mut *self.conn).poll_write(cx, buf))?;
+        Poll::Ready(Ok(amt))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut *self.conn).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut *self.conn).poll_close(cx)
+    }
+}
+
+#[async_trait]
+impl Manager<TcpStream, std::io::Error> for TcpConnection {
+    async fn create(&self) -> Result<TcpStream, std::io::Error> {
+        Ok(TcpStream::connect(self.addr).await?)
+    }
+
+    async fn recycle(&self, _conn: &mut TcpStream) -> RecycleResult<std::io::Error> {
+        Ok(())
+    }
+}

--- a/src/h1/tls.rs
+++ b/src/h1/tls.rs
@@ -1,0 +1,93 @@
+use std::fmt::Debug;
+use std::net::SocketAddr;
+use std::pin::Pin;
+
+use async_std::net::TcpStream;
+use async_trait::async_trait;
+use deadpool::managed::{Manager, Object, RecycleResult};
+use futures::io::{AsyncRead, AsyncWrite};
+use futures::task::{Context, Poll};
+
+#[cfg(not(feature = "h1_client_rustls"))]
+use async_native_tls::TlsStream;
+#[cfg(feature = "h1_client_rustls")]
+use async_tls::client::TlsStream;
+
+use crate::Error;
+
+#[derive(Clone, Debug)]
+pub(crate) struct TlsConnection {
+    host: String,
+    addr: SocketAddr,
+}
+impl TlsConnection {
+    pub(crate) fn new(host: String, addr: SocketAddr) -> Self {
+        Self { host, addr }
+    }
+}
+
+pub(crate) struct TlsConnWrapper {
+    conn: Object<TlsStream<TcpStream>, Error>,
+}
+impl TlsConnWrapper {
+    pub(crate) fn new(conn: Object<TlsStream<TcpStream>, Error>) -> Self {
+        Self { conn }
+    }
+}
+
+impl AsyncRead for TlsConnWrapper {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        Pin::new(&mut *self.conn).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for TlsConnWrapper {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        let amt = futures::ready!(Pin::new(&mut *self.conn).poll_write(cx, buf))?;
+        Poll::Ready(Ok(amt))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut *self.conn).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut *self.conn).poll_close(cx)
+    }
+}
+
+#[async_trait]
+impl Manager<TlsStream<TcpStream>, Error> for TlsConnection {
+    async fn create(&self) -> Result<TlsStream<TcpStream>, Error> {
+        log::trace!("Creating new socket to {:?}", self.addr);
+        let raw_stream = async_std::net::TcpStream::connect(self.addr).await?;
+        let tls_stream = add_tls(&self.host, raw_stream).await?;
+        Ok(tls_stream)
+    }
+
+    async fn recycle(&self, _conn: &mut TlsStream<TcpStream>) -> RecycleResult<Error> {
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "h1_client_rustls"))]
+async fn add_tls(
+    host: &str,
+    stream: TcpStream,
+) -> Result<async_native_tls::TlsStream<TcpStream>, async_native_tls::Error> {
+    async_native_tls::connect(host, stream).await
+}
+
+#[cfg(feature = "h1_client_rustls")]
+async fn add_tls(host: &str, stream: TcpStream) -> Result<TlsStream<TcpStream>, std::io::Error> {
+    let connector = async_tls::TlsConnector::default();
+    connector.connect(host, stream).await
+}

--- a/src/h1/tls.rs
+++ b/src/h1/tls.rs
@@ -51,8 +51,7 @@ impl AsyncWrite for TlsConnWrapper {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<std::io::Result<usize>> {
-        let amt = futures::ready!(Pin::new(&mut *self.conn).poll_write(cx, buf))?;
-        Poll::Ready(Ok(amt))
+        Pin::new(&mut *self.conn).poll_write(cx, buf)
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
@@ -67,7 +66,6 @@ impl AsyncWrite for TlsConnWrapper {
 #[async_trait]
 impl Manager<TlsStream<TcpStream>, Error> for TlsConnection {
     async fn create(&self) -> Result<TlsStream<TcpStream>, Error> {
-        log::trace!("Creating new socket to {:?}", self.addr);
         let raw_stream = async_std::net::TcpStream::connect(self.addr).await?;
         let tls_stream = add_tls(&self.host, raw_stream).await?;
         Ok(tls_stream)


### PR DESCRIPTION
> This is imported from the orogene project, with massive thanks to Kat Marchán (@zkat) for letting us re-use this work.
> 
> Specifically:
> https://github.com/orogene/orogene/tree/82b5c1e6773ceb3ee5a06c8273d7262d6073ce43/crates/oro-client/src/http_client

This includes the code from there in the first commit, with a few follow-up commits with clean-up and improvements.

If anyone has suggestions on how to write a test for `Keep-Alive` that would be appreciated, otherwise I'll go digging about in `hyper` I suppose.