### PR TITLE
change: separate out tls feature flags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        backend: [h1_client, hyper_client, curl_client]
+        backend: ["h1_client,native-tls", hyper_client, curl_client]
 
     steps:
     - uses: actions/checkout@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,17 @@ features = ["docs"]
 rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
-default = ["h1_client"]
+default = ["h1_client", "native-tls"]
 docs = ["h1_client", "curl_client", "wasm_client", "hyper_client"]
-h1_client = ["async-h1", "async-std", "async-native-tls", "deadpool", "futures"]
-h1_client_rustls = ["async-h1", "async-std", "async-tls", "deadpool", "futures"]
+
+h1_client = ["async-h1", "async-std", "deadpool", "futures"]
 native_client = ["curl_client", "wasm_client"]
 curl_client = ["isahc", "async-std"]
 wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures", "futures"]
 hyper_client = ["hyper", "hyper-tls", "http-types/hyperium_http", "futures-util"]
+
+native-tls = ["async-native-tls"]
+rustls = ["async-tls"]
 
 [dependencies]
 async-trait = "0.1.37"

--- a/src/h1/mod.rs
+++ b/src/h1/mod.rs
@@ -9,9 +9,9 @@ use dashmap::DashMap;
 use deadpool::managed::Pool;
 use http_types::StatusCode;
 
-#[cfg(not(feature = "h1_client_rustls"))]
+#[cfg(feature = "native-tls")]
 use async_native_tls::TlsStream;
-#[cfg(feature = "h1_client_rustls")]
+#[cfg(feature = "rustls")]
 use async_tls::client::TlsStream;
 
 use super::{async_trait, Error, HttpClient, Request, Response};

--- a/src/h1/tls.rs
+++ b/src/h1/tls.rs
@@ -8,9 +8,9 @@ use deadpool::managed::{Manager, Object, RecycleResult};
 use futures::io::{AsyncRead, AsyncWrite};
 use futures::task::{Context, Poll};
 
-#[cfg(not(feature = "h1_client_rustls"))]
+#[cfg(feature = "native-tls")]
 use async_native_tls::TlsStream;
-#[cfg(feature = "h1_client_rustls")]
+#[cfg(feature = "rustls")]
 use async_tls::client::TlsStream;
 
 use crate::Error;
@@ -76,15 +76,15 @@ impl Manager<TlsStream<TcpStream>, Error> for TlsConnection {
     }
 }
 
-#[cfg(not(feature = "h1_client_rustls"))]
+#[cfg(feature = "native-tls")]
 async fn add_tls(
     host: &str,
     stream: TcpStream,
-) -> Result<async_native_tls::TlsStream<TcpStream>, async_native_tls::Error> {
+) -> Result<TlsStream<TcpStream>, async_native_tls::Error> {
     async_native_tls::connect(host, stream).await
 }
 
-#[cfg(feature = "h1_client_rustls")]
+#[cfg(feature = "rustls")]
 async fn add_tls(host: &str, stream: TcpStream) -> Result<TlsStream<TcpStream>, std::io::Error> {
     let connector = async_tls::TlsConnector::default();
     connector.connect(host, stream).await


### PR DESCRIPTION
A successor to https://github.com/http-rs/http-client/pull/53, this separates out the tls feature flags, which should be nicer.

Fixes: https://github.com/http-rs/http-client/issues/54