### PR TITLE
Fix h1_client feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-    
+
       - name: check
         run: cargo check --no-default-features
 
@@ -51,7 +51,7 @@ jobs:
         override: true
         components: clippy, rustfmt
 
-    - name: clippy 
+    - name: clippy
       run: cargo clippy --all-targets --workspace --features=docs
 
     - name: fmt
@@ -79,3 +79,18 @@ jobs:
       with:
         command: check
         args: --target wasm32-unknown-unknown --no-default-features --features "native_client,wasm_client"
+
+  check_features:
+    name: Check feature combinations
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Install cargo-hack
+      run: cargo install cargo-hack
+
+    - name: Check all feature combinations works properly
+      # * `--feature-powerset` - run for the feature powerset of the package
+      # * `--no-dev-deps` - build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
+      # * `--skip docs` - skip `docs` feature
+      run: cargo hack check --feature-powerset --no-dev-deps --skip docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ async-trait = "0.1.37"
 dashmap = "4.0.2"
 http-types = "2.3.0"
 log = "0.4.7"
+cfg-if = "1.0.0"
 
 # h1_client
 async-h1 = { version = "2.0.0", optional = true }
@@ -91,5 +92,4 @@ tide-rustls = { version = "0.1.4" }
 tokio = { version = "0.2.21", features = ["macros"] }
 serde = "1.0"
 serde_json = "1.0"
-cfg-if = "0.1.10"
 mockito = "0.23.3"


### PR DESCRIPTION
Context: https://github.com/http-rs/http-client/pull/67#issuecomment-778734155

* When both "native-tls" and "rustls" features are disabled, disable https.
* When both "native-tls" and "rustls" features are enabled, prefer "rustls".
  This is the same behavior as http-client 6.2.0.
  Ideally, it would be nice if this behavior could be controlled by
  environment variables or some other way.

This also adds a CI task to check all feature combinations work properly. (see https://github.com/http-rs/surf/pull/282 for more)