### PR TITLE
fix h1 connection pooling

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -135,3 +135,20 @@ SOFTWARE.
 
     Ok(())
 }
+
+#[async_std::test]
+async fn keep_alive() {
+    let _mock_guard = mockito::mock("GET", "/report")
+        .with_status(200)
+        .expect_at_least(2)
+        .create();
+
+    let client = DefaultClient::new();
+    let url: Url = format!("{}/report", mockito::server_url()).parse().unwrap();
+    let req = Request::new(
+        http_types::Method::Get,
+        url
+    );
+    client.send(req.clone()).await.unwrap();
+    client.send(req.clone()).await.unwrap();
+}


### PR DESCRIPTION
Except don't because this does not actually work, because as far as I can tell this need to somehow poll `poll_read()` and not `read()`...