### PR TITLE
h1: Fix connection with multiple IPs for a hostname

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -149,3 +149,19 @@ async fn keep_alive() {
     client.send(req.clone()).await.unwrap();
     client.send(req.clone()).await.unwrap();
 }
+
+#[atest]
+async fn fallback_to_ipv4() {
+    let client = DefaultClient::new();
+    let _mock_guard = mock("GET", "/")
+        .with_status(200)
+        .expect_at_least(2)
+        .create();
+
+    // Kips the initial "http://127.0.0.1:" to get only the port number
+    let mock_port = &mockito::server_url()[17..];
+
+    let url = &format!("http://localhost:{}", mock_port);
+    let req = Request::new(http_types::Method::Get, Url::parse(url).unwrap());
+    client.send(req.clone()).await.unwrap();
+}


### PR DESCRIPTION
When trying to connect to multiple IPs for a hostname (e.g. IPv4 and
IPv6) we ought to try all prior returning error.

Running a wget to the running mockito server has this output:

,----
| $ wget -O- http://localhost:1234/report
| --2021-03-08 16:13:12--  http://localhost:1234/report
| Resolving localhost (localhost)... ::1, 127.0.0.1
| Connecting to localhost (localhost)|::1|:1234... failed: Connection refused.
| Connecting to localhost (localhost)|127.0.0.1|:1234... connected.
| HTTP request sent, awaiting response... 200 OK
`----

Fixes: #79.
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>