### PR TITLE
Fix warning due to old lint name related to rustdoc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 
 #![forbid(future_incompatible, rust_2018_idioms)]
 #![deny(missing_debug_implementations, nonstandard_style)]
-#![warn(missing_docs, missing_doc_code_examples, unreachable_pub)]
+#![warn(missing_docs, rustdoc::missing_doc_code_examples, unreachable_pub)]
 #![cfg_attr(feature = "docs", feature(doc_cfg))]
 // Forbid `unsafe` for the native & curl features, but allow it (for now) under the WASM backend
 #![cfg_attr(


### PR DESCRIPTION
This update the code to use the new `rustdoc::missing_doc_code_examples`
lint.

Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>