### PR TITLE
Use append_header, not insert_header

### DIFF
--- a/src/hyper.rs
+++ b/src/hyper.rs
@@ -130,7 +130,7 @@ impl HttpTypesResponse {
             if let Some(name) = name {
                 let name = name.as_str();
                 let name = HeaderName::from_str(name)?;
-                res.insert_header(name, value);
+                res.append_header(name, value);
             }
         }
 

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -51,7 +51,7 @@ impl HttpClient for IsahcClient {
         let body = Body::from_reader(BufReader::new(body), None);
         let mut response = http_types::Response::new(parts.status.as_u16());
         for (name, value) in &parts.headers {
-            response.insert_header(name.as_str(), value.to_str().unwrap());
+            response.append_header(name.as_str(), value.to_str().unwrap());
         }
 
         if let Some(metrics) = maybe_metrics {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -40,7 +40,7 @@ impl HttpClient for WasmClient {
             response.set_body(Body::from(body));
             for (name, value) in res.headers() {
                 let name: http_types::headers::HeaderName = name.parse().unwrap();
-                response.insert_header(&name, value);
+                response.append_header(&name, value);
             }
 
             Ok(response)


### PR DESCRIPTION
Fixes https://github.com/http-rs/surf/issues/297

Handily, the h1 client doesn't need to be changed, because [it already correctly uses `append_header`](https://github.com/http-rs/async-h1/blob/main/src/client/decode.rs#L69).