### PR TITLE
docs: add "unstable-config" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
 default = ["h1_client", "native-tls"]
-docs = ["h1_client", "curl_client", "wasm_client", "hyper_client"]
+docs = ["h1_client", "curl_client", "wasm_client", "hyper_client", "unstable-config"]
 
 h1_client = ["async-h1", "async-std", "deadpool", "futures"]
 native_client = ["curl_client", "wasm_client"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use std::fmt::Debug;
 use std::time::Duration;
 
 /// Configuration for `HttpClient`s.
+#[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
 #[non_exhaustive]
 #[derive(Clone)]
 pub struct Config {
@@ -20,9 +21,11 @@ pub struct Config {
     /// Default: `Some(Duration::from_secs(60))`.
     pub timeout: Option<Duration>,
     /// TLS Configuration (Rustls)
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "h1_client")))]
     #[cfg(all(feature = "h1_client", feature = "rustls"))]
     pub tls_config: Option<std::sync::Arc<rustls_crate::ClientConfig>>,
     /// TLS Configuration (Native TLS)
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "h1_client")))]
     #[cfg(all(feature = "h1_client", feature = "native-tls", not(feature = "rustls")))]
     pub tls_config: Option<std::sync::Arc<async_native_tls::TlsConnector>>,
 }
@@ -91,6 +94,7 @@ impl Config {
     }
 
     /// Set TLS Configuration (Rustls)
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "h1_client")))]
     #[cfg(all(feature = "h1_client", feature = "rustls"))]
     pub fn set_tls_config(
         mut self,
@@ -100,6 +104,7 @@ impl Config {
         self
     }
     /// Set TLS Configuration (Native TLS)
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "h1_client")))]
     #[cfg(all(feature = "h1_client", feature = "native-tls", not(feature = "rustls")))]
     pub fn set_tls_config(
         mut self,

--- a/src/h1/mod.rs
+++ b/src/h1/mod.rs
@@ -1,4 +1,4 @@
-//! http-client implementation for async-h1, with connecton pooling ("Keep-Alive").
+//! http-client implementation for async-h1, with connection pooling ("Keep-Alive").
 
 #[cfg(feature = "unstable-config")]
 use std::convert::{Infallible, TryFrom};
@@ -272,6 +272,7 @@ impl HttpClient for H1Client {
         ))
     }
 
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
     #[cfg(feature = "unstable-config")]
     /// Override the existing configuration with new configuration.
     ///
@@ -282,6 +283,7 @@ impl HttpClient for H1Client {
         Ok(())
     }
 
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
     #[cfg(feature = "unstable-config")]
     /// Get the current configuration.
     fn config(&self) -> &Config {
@@ -289,6 +291,7 @@ impl HttpClient for H1Client {
     }
 }
 
+#[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
 #[cfg(feature = "unstable-config")]
 impl TryFrom<Config> for H1Client {
     type Error = Infallible;

--- a/src/hyper.rs
+++ b/src/hyper.rs
@@ -92,6 +92,7 @@ impl HttpClient for HyperClient {
         Ok(res)
     }
 
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
     #[cfg(feature = "unstable-config")]
     /// Override the existing configuration with new configuration.
     ///
@@ -110,6 +111,7 @@ impl HttpClient for HyperClient {
         Ok(())
     }
 
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
     #[cfg(feature = "unstable-config")]
     /// Get the current configuration.
     fn config(&self) -> &Config {
@@ -117,6 +119,7 @@ impl HttpClient for HyperClient {
     }
 }
 
+#[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
 #[cfg(feature = "unstable-config")]
 impl TryFrom<Config> for HyperClient {
     type Error = Infallible;

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -75,6 +75,7 @@ impl HttpClient for IsahcClient {
         Ok(response)
     }
 
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
     #[cfg(feature = "unstable-config")]
     /// Override the existing configuration with new configuration.
     ///
@@ -98,6 +99,7 @@ impl HttpClient for IsahcClient {
         Ok(())
     }
 
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
     #[cfg(feature = "unstable-config")]
     /// Get the current configuration.
     fn config(&self) -> &Config {
@@ -105,6 +107,7 @@ impl HttpClient for IsahcClient {
     }
 }
 
+#[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
 #[cfg(feature = "unstable-config")]
 impl TryFrom<Config> for IsahcClient {
     type Error = isahc::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,24 +21,24 @@ pub use config::Config;
 #[cfg(not(feature = "unstable-config"))]
 type Config = ();
 
-#[cfg_attr(feature = "docs", doc(cfg(curl_client)))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "curl_client")))]
 #[cfg(all(feature = "curl_client", not(target_arch = "wasm32")))]
 pub mod isahc;
 
-#[cfg_attr(feature = "docs", doc(cfg(wasm_client)))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "wasm_client")))]
 #[cfg(all(feature = "wasm_client", target_arch = "wasm32"))]
 pub mod wasm;
 
-#[cfg_attr(feature = "docs", doc(cfg(native_client)))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "native_client")))]
 #[cfg(any(feature = "curl_client", feature = "wasm_client"))]
 pub mod native;
 
-#[cfg_attr(feature = "docs", doc(cfg(h1_client)))]
-#[cfg_attr(feature = "docs", doc(cfg(default)))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "h1_client")))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "default")))]
 #[cfg(any(feature = "h1_client", feature = "h1_client_rustls"))]
 pub mod h1;
 
-#[cfg_attr(feature = "docs", doc(cfg(hyper_client)))]
+#[cfg_attr(feature = "docs", doc(cfg(feature = "hyper_client")))]
 #[cfg(feature = "hyper_client")]
 pub mod hyper;
 
@@ -106,11 +106,13 @@ impl HttpClient for Box<dyn HttpClient> {
         self.as_ref().send(req).await
     }
 
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
     #[cfg(feature = "unstable-config")]
     fn set_config(&mut self, config: Config) -> http_types::Result<()> {
         self.as_mut().set_config(config)
     }
 
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
     #[cfg(feature = "unstable-config")]
     fn config(&self) -> &Config {
         self.as_ref().config()


### PR DESCRIPTION
Some of the spots don't actually highlight the feature correctly in the docs, notably the functions on the trait.