### PR TITLE
bump dependency: async-tls, rustls_crate, async-h1, async-native-tls,…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,15 +42,15 @@ log = "0.4.7"
 cfg-if = "1.0.0"
 
 # h1_client
-async-h1 = { version = "2.0.0", optional = true }
+async-h1 = { version = "2.3.2", optional = true }
 async-std = { version = "1.6.0", default-features = false, optional = true }
-async-native-tls = { version = "0.3.1", optional = true }
+async-native-tls = { version = "0.3.3", optional = true }
 deadpool = { version = "0.7.0", optional = true }
 futures = { version = "0.3.8", optional = true }
 
 # h1_client_rustls
-async-tls = { version = "0.10.0", optional = true }
-rustls_crate = { version = "0.18", optional = true, package = "rustls" }
+async-tls = { version = "0.11.0", optional = true }
+rustls_crate = { version = "0.19.1", optional = true, package = "rustls" }
 
 # hyper_client
 hyper = { version = "0.13.6", features = ["tcp"], optional = true }
@@ -60,7 +60,7 @@ tokio = { version = "0.2", features = ["time"], optional = true }
 
 # curl_client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-isahc = { version = "0.9", optional = true, default-features = false, features = ["http2"]  }
+isahc = { version = "1.4.0", optional = true, default-features = false, features = ["http2"]  }
 
 # wasm_client
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ cfg-if = "1.0.0"
 # h1_client
 async-h1 = { version = "2.3.2", optional = true }
 async-std = { version = "1.6.0", default-features = false, optional = true }
-async-native-tls = { version = "0.3.3", optional = true }
+async-native-tls = { version = "0.3", optional = true }
 deadpool = { version = "0.7.0", optional = true }
 futures = { version = "0.3.8", optional = true }
 
@@ -60,7 +60,7 @@ tokio = { version = "0.2", features = ["time"], optional = true }
 
 # curl_client
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-isahc = { version = "1.4.0", optional = true, default-features = false, features = ["http2"]  }
+isahc = { version = "0.9", optional = true, default-features = false, features = ["http2"]  }
 
 # wasm_client
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -53,8 +53,8 @@ impl HttpClient for IsahcClient {
 
         let body = req.take_body();
         let body = match body.len() {
-            Some(len) => isahc::Body::from_reader_sized(body, len as u64),
-            None => isahc::Body::from_reader(body),
+            Some(len) => isahc::AsyncBody::from_reader_sized(body, len as u64),
+            None => isahc::AsyncBody::from_reader(body),
         };
 
         let request = builder.body(body).unwrap();


### PR DESCRIPTION
Would like to use h1_client_rustls with surf, tide and rustls in one crate, for this it was necessary to update the dependencies of http-client.