### PR TITLE
Stabilize config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ docs = ["h1_client", "curl_client", "wasm_client", "hyper_client", "unstable-con
 h1_client = ["async-h1", "async-std", "deadpool", "futures"]
 native_client = ["curl_client", "wasm_client"]
 curl_client = ["isahc", "async-std"]
-wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures", "futures"]
+wasm_client = ["js-sys", "web-sys", "wasm-bindgen", "wasm-bindgen-futures", "futures", "async-std"]
 hyper_client = ["hyper", "hyper-tls", "http-types/hyperium_http", "futures-util", "tokio"]
 
 native-tls = ["async-native-tls"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rustdoc-args = ["--cfg", "feature=\"docs\""]
 
 [features]
 default = ["h1_client", "native-tls"]
-docs = ["h1_client", "curl_client", "wasm_client", "hyper_client", "unstable-config"]
+docs = ["h1_client", "curl_client", "wasm_client", "hyper_client"]
 
 h1_client = ["async-h1", "async-std", "deadpool", "futures"]
 native_client = ["curl_client", "wasm_client"]
@@ -32,7 +32,7 @@ hyper_client = ["hyper", "hyper-tls", "http-types/hyperium_http", "futures-util"
 native-tls = ["async-native-tls"]
 rustls = ["async-tls", "rustls_crate"]
 
-unstable-config = []
+unstable-config = [] # deprecated
 
 [dependencies]
 async-trait = "0.1.37"

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,10 +11,14 @@ pub struct Config {
     /// HTTP/1.1 `keep-alive` (connection pooling).
     ///
     /// Default: `true`.
+    ///
+    /// Note: Does nothing on `wasm_client`.
     pub http_keep_alive: bool,
     /// TCP `NO_DELAY`.
     ///
     /// Default: `false`.
+    ///
+    /// Note: Does nothing on `wasm_client`.
     pub tcp_no_delay: bool,
     /// Connection timeout duration.
     ///

--- a/src/h1/mod.rs
+++ b/src/h1/mod.rs
@@ -99,6 +99,10 @@ impl H1Client {
     }
 
     /// Create a new instance.
+    #[deprecated(
+        since = "6.5.0",
+        note = "This function is misnamed. Prefer `Config::max_connections_per_host` instead."
+    )]
     pub fn with_max_connections(max: usize) -> Self {
         #[cfg(features = "h1_client")]
         assert!(max > 0, "max_connections_per_host with h1_client must be greater than zero or it will deadlock!");

--- a/src/h1/tcp.rs
+++ b/src/h1/tcp.rs
@@ -65,7 +65,6 @@ impl Manager<TcpStream, std::io::Error> for TcpConnection {
     async fn create(&self) -> Result<TcpStream, std::io::Error> {
         let tcp_stream = TcpStream::connect(self.addr).await?;
 
-        #[cfg(feature = "unstable-config")]
         tcp_stream.set_nodelay(self.config.tcp_no_delay)?;
 
         Ok(tcp_stream)
@@ -75,7 +74,6 @@ impl Manager<TcpStream, std::io::Error> for TcpConnection {
         let mut buf = [0; 4];
         let mut cx = Context::from_waker(futures::task::noop_waker_ref());
 
-        #[cfg(feature = "unstable-config")]
         conn.set_nodelay(self.config.tcp_no_delay)?;
 
         match Pin::new(conn).poll_read(&mut cx, &mut buf) {

--- a/src/hyper.rs
+++ b/src/hyper.rs
@@ -1,8 +1,6 @@
 //! http-client implementation for reqwest
 
-#[cfg(feature = "unstable-config")]
-use std::convert::Infallible;
-use std::convert::TryFrom;
+use std::convert::{Infallible, TryFrom};
 use std::fmt::Debug;
 use std::io;
 use std::str::FromStr;
@@ -74,7 +72,6 @@ impl HttpClient for HyperClient {
         let req = HyperHttpRequest::try_from(req).await?.into_inner();
 
         let conn_fut = self.client.dyn_request(req);
-        #[cfg(feature = "unstable-config")]
         let response = if let Some(timeout) = self.config.timeout {
             match tokio::time::timeout(timeout, conn_fut).await {
                 Err(_elapsed) => Err(Error::from_str(400, "Client timed out")),
@@ -85,15 +82,10 @@ impl HttpClient for HyperClient {
             conn_fut.await?
         };
 
-        #[cfg(not(feature = "unstable-config"))]
-        let response = conn_fut.await?;
-
         let res = HttpTypesResponse::try_from(response).await?.into_inner();
         Ok(res)
     }
 
-    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-    #[cfg(feature = "unstable-config")]
     /// Override the existing configuration with new configuration.
     ///
     /// Config options may not impact existing connections.
@@ -111,16 +103,12 @@ impl HttpClient for HyperClient {
         Ok(())
     }
 
-    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-    #[cfg(feature = "unstable-config")]
     /// Get the current configuration.
     fn config(&self) -> &Config {
         &self.config
     }
 }
 
-#[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-#[cfg(feature = "unstable-config")]
 impl TryFrom<Config> for HyperClient {
     type Error = Infallible;
 

--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -1,10 +1,8 @@
 //! http-client implementation for isahc
 
-#[cfg(feature = "unstable-config")]
 use std::convert::TryFrom;
 
 use async_std::io::BufReader;
-#[cfg(feature = "unstable-config")]
 use isahc::config::Configurable;
 use isahc::{http, ResponseExt};
 
@@ -75,13 +73,12 @@ impl HttpClient for IsahcClient {
         Ok(response)
     }
 
-    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-    #[cfg(feature = "unstable-config")]
     /// Override the existing configuration with new configuration.
     ///
     /// Config options may not impact existing connections.
     fn set_config(&mut self, config: Config) -> http_types::Result<()> {
-        let mut builder = isahc::HttpClient::builder();
+        let mut builder =
+            isahc::HttpClient::builder().max_connections_per_host(config.max_connections_per_host);
 
         if !config.http_keep_alive {
             builder = builder.connection_cache_size(0);
@@ -99,16 +96,12 @@ impl HttpClient for IsahcClient {
         Ok(())
     }
 
-    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-    #[cfg(feature = "unstable-config")]
     /// Get the current configuration.
     fn config(&self) -> &Config {
         &self.config
     }
 }
 
-#[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-#[cfg(feature = "unstable-config")]
 impl TryFrom<Config> for IsahcClient {
     type Error = isahc::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,8 @@
     forbid(unsafe_code)
 )]
 
-#[cfg(feature = "unstable-config")]
 mod config;
-#[cfg(feature = "unstable-config")]
 pub use config::Config;
-#[cfg(not(feature = "unstable-config"))]
-type Config = ();
 
 #[cfg_attr(feature = "docs", doc(cfg(feature = "curl_client")))]
 #[cfg(all(feature = "curl_client", not(target_arch = "wasm32")))]
@@ -68,7 +64,6 @@ pub trait HttpClient: std::fmt::Debug + Unpin + Send + Sync + 'static {
     /// Perform a request.
     async fn send(&self, req: Request) -> Result<Response, Error>;
 
-    #[cfg(feature = "unstable-config")]
     /// Override the existing configuration with new configuration.
     ///
     /// Config options may not impact existing connections.
@@ -79,7 +74,6 @@ pub trait HttpClient: std::fmt::Debug + Unpin + Send + Sync + 'static {
         )
     }
 
-    #[cfg(feature = "unstable-config")]
     /// Get the current configuration.
     fn config(&self) -> &Config {
         unimplemented!(
@@ -89,7 +83,6 @@ pub trait HttpClient: std::fmt::Debug + Unpin + Send + Sync + 'static {
     }
 }
 
-#[cfg(feature = "unstable-config")]
 fn type_name_of<T: ?Sized>(_val: &T) -> &'static str {
     std::any::type_name::<T>()
 }
@@ -106,14 +99,10 @@ impl HttpClient for Box<dyn HttpClient> {
         self.as_ref().send(req).await
     }
 
-    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-    #[cfg(feature = "unstable-config")]
     fn set_config(&mut self, config: Config) -> http_types::Result<()> {
         self.as_mut().set_config(config)
     }
 
-    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-    #[cfg(feature = "unstable-config")]
     fn config(&self) -> &Config {
         self.as_ref().config()
     }

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -1,9 +1,6 @@
 //! http-client implementation for fetch
 
-#[cfg(feature = "unstable-config")]
-use std::convert::Infallible;
-
-use std::convert::TryFrom;
+use std::convert::{Infallible, TryFrom};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -22,7 +19,9 @@ pub struct WasmClient {
 impl WasmClient {
     /// Create a new instance.
     pub fn new() -> Self {
-        Self { config: Config::default() }
+        Self {
+            config: Config::default(),
+        }
     }
 }
 
@@ -46,14 +45,11 @@ impl HttpClient for WasmClient {
         InnerFuture::new(async move {
             let req: fetch::Request = fetch::Request::new(req).await?;
             let conn = req.send();
-            #[cfg(feature = "unstable-config")]
             let mut res = if let Some(timeout) = config.timeout {
                 async_std::future::timeout(timeout, conn).await??
             } else {
                 conn.await?
             };
-            #[cfg(not(feature = "unstable-config"))]
-            let mut res = conn.await?;
 
             let body = res.body_bytes();
             let mut response =
@@ -68,8 +64,6 @@ impl HttpClient for WasmClient {
         })
     }
 
-    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-    #[cfg(feature = "unstable-config")]
     /// Override the existing configuration with new configuration.
     ///
     /// Config options may not impact existing connections.
@@ -79,23 +73,17 @@ impl HttpClient for WasmClient {
         Ok(())
     }
 
-    #[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-    #[cfg(feature = "unstable-config")]
     /// Get the current configuration.
     fn config(&self) -> &Config {
         &self.config
     }
 }
 
-#[cfg_attr(feature = "docs", doc(cfg(feature = "unstable-config")))]
-#[cfg(feature = "unstable-config")]
 impl TryFrom<Config> for WasmClient {
     type Error = Infallible;
 
     fn try_from(config: Config) -> Result<Self, Self::Error> {
-        Ok(Self {
-            config,
-        })
+        Ok(Self { config })
     }
 }
 


### PR DESCRIPTION
I've been using this in projects for a couple months now, and would like to land support in Surf directly, for which this should be stabilized.

This also adds the following things for stabilization:
- wasm support for `Config`
    - Only supports `timeout`, unfortunately, and requires async-std...
- `Config::max_connections_per_host`
    - The behavior of this is different depending on the backend in use, unfortunately.
- `H1Client::with_max_connections()` has been deprecated.