### PR TITLE
Upgrade `rustls` to 0.19 and `async-tls` to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ deadpool = { version = "0.7.0", optional = true }
 futures = { version = "0.3.8", optional = true }
 
 # h1_client_rustls
-async-tls = { version = "0.10.0", optional = true }
+async-tls = { version = "0.11", optional = true }
 rustls_crate = { version = "0.19", optional = true, package = "rustls" }
 
 # hyper_client

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ futures = { version = "0.3.8", optional = true }
 
 # h1_client_rustls
 async-tls = { version = "0.10.0", optional = true }
-rustls_crate = { version = "0.18", optional = true, package = "rustls" }
+rustls_crate = { version = "0.19", optional = true, package = "rustls" }
 
 # hyper_client
 hyper = { version = "0.13.6", features = ["tcp"], optional = true }


### PR DESCRIPTION
The 0.20 upgrade of `rustls` would have been much more substantial with quite a few breaking changes, so this is not included.