### PR TITLE
safety: Use send_wrapper in WASM instead of unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ js-sys = { version = "0.3.25", optional = true }
 wasm-bindgen = { version = "0.2.48", optional = true }
 wasm-bindgen-futures = { version = "0.4.5", optional = true }
 futures = { version = "0.3.1", optional = true }
+send_wrapper = { version = "0.6.0", features = ["futures"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
 version = "0.3.25"


### PR DESCRIPTION
Resolves https://github.com/http-rs/http-client/issues/40

`unsafe impl Send for InnerFuture {}` will become unsound when WebAssembly supports threads. This PR adds `send_wrapper::SendWrapper` as a runtime check that will panic instead of causing undefined behavior.