### PR TITLE
Bump `dashmap` to v5.3.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ cfg-if = "1.0.0"
 async-h1 = { version = "2.0.0", optional = true }
 async-std = { version = "1.6.0", default-features = false, optional = true }
 async-native-tls = { version = "0.3.1", optional = true }
-dashmap = { version = "4.0.2", optional = true }
+dashmap = { version = "5.3.4", optional = true }
 deadpool = { version = "0.7.0", optional = true }
 futures = { version = "0.3.8", optional = true }
 


### PR DESCRIPTION
This fixes https://github.com/advisories/GHSA-mpg5-fvwp-42m2, "Unsoundness in `dashmap` references," for versions `< 5.1.0`.