### PR TITLE
Fix wrong kind of timeout set to isahc

### DIFF
--- a/src/isahc.rs
+++ b/src/isahc.rs
@@ -87,7 +87,7 @@ impl HttpClient for IsahcClient {
             builder = builder.tcp_nodelay();
         }
         if let Some(timeout) = config.timeout {
-            builder = builder.timeout(timeout);
+            builder = builder.connect_timeout(timeout);
         }
 
         self.client = builder.build()?;
@@ -115,7 +115,7 @@ impl TryFrom<Config> for IsahcClient {
             builder = builder.tcp_nodelay();
         }
         if let Some(timeout) = config.timeout {
-            builder = builder.timeout(timeout);
+            builder = builder.connect_timeout(timeout);
         }
 
         Ok(Self {


### PR DESCRIPTION
closes #103 

---

This is not related to the changes in this pull request, but I will note it here anyway. The two functions I modified this time, one sets max_connections_per_host and the other does not. Perhaps this should be set in both cases.
