### PR TITLE
Upgrade deadpool dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ unstable-config = [] # deprecated
 
 [dependencies]
 async-trait = "0.1.37"
-http-types = "2.3.0"
+http-types = "2.12.0"
 log = "0.4.7"
 cfg-if = "1.0.0"
 
@@ -45,7 +45,7 @@ async-h1 = { version = "2.0.0", optional = true }
 async-std = { version = "1.6.0", default-features = false, optional = true }
 async-native-tls = { version = "0.3.1", optional = true }
 dashmap = { version = "5.3.4", optional = true }
-deadpool = { version = "0.7.0", optional = true }
+deadpool = { version = "0.9.5", optional = true }
 futures = { version = "0.3.8", optional = true }
 
 # h1_client_rustls

--- a/src/h1/tcp.rs
+++ b/src/h1/tcp.rs
@@ -24,10 +24,10 @@ impl TcpConnection {
 }
 
 pub(crate) struct TcpConnWrapper {
-    conn: Object<TcpStream, std::io::Error>,
+    conn: Object<TcpConnection>,
 }
 impl TcpConnWrapper {
-    pub(crate) fn new(conn: Object<TcpStream, std::io::Error>) -> Self {
+    pub(crate) fn new(conn: Object<TcpConnection>) -> Self {
         Self { conn }
     }
 }
@@ -61,7 +61,10 @@ impl AsyncWrite for TcpConnWrapper {
 }
 
 #[async_trait]
-impl Manager<TcpStream, std::io::Error> for TcpConnection {
+impl Manager for TcpConnection {
+    type Type = TcpStream;
+    type Error = std::io::Error;
+
     async fn create(&self) -> Result<TcpStream, std::io::Error> {
         let tcp_stream = TcpStream::connect(self.addr).await?;
 

--- a/src/h1/tls.rs
+++ b/src/h1/tls.rs
@@ -33,10 +33,10 @@ impl TlsConnection {
 }
 
 pub(crate) struct TlsConnWrapper {
-    conn: Object<TlsStream<TcpStream>, Error>,
+    conn: Object<TlsConnection>,
 }
 impl TlsConnWrapper {
-    pub(crate) fn new(conn: Object<TlsStream<TcpStream>, Error>) -> Self {
+    pub(crate) fn new(conn: Object<TlsConnection>) -> Self {
         Self { conn }
     }
 }
@@ -70,7 +70,10 @@ impl AsyncWrite for TlsConnWrapper {
 }
 
 #[async_trait]
-impl Manager<TlsStream<TcpStream>, Error> for TlsConnection {
+impl Manager for TlsConnection {
+    type Type = TlsStream<TcpStream>;
+    type Error = Error;
+
     async fn create(&self) -> Result<TlsStream<TcpStream>, Error> {
         let raw_stream = async_std::net::TcpStream::connect(self.addr).await?;
 


### PR DESCRIPTION
As described in #109, this issue upgrades the [`deadpool`](https://crates.io/crates/deadpool) dependency, which through a chain of dependencies relies on an outdated version of [`nom`](https://crates.io/crates/nom) which has code that rustc now emits a deprecation warning for:

```
    Finished dev [unoptimized + debuginfo] target(s) in 4m 49s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 35`
```

The other dependencies in this chain are already upgraded, so fixing the use here in `http-client` will result in downstream users no longer having this rustc warning appear.